### PR TITLE
Configurable multiple value separator for NestedArrayAdapter

### DIFF
--- a/Model/Adapters/NestedArrayAdapter.php
+++ b/Model/Adapters/NestedArrayAdapter.php
@@ -9,12 +9,17 @@ namespace FireGento\FastSimpleImport\Model\Adapters;
 
 class NestedArrayAdapter extends ArrayAdapter
 {
+    protected $multipleValueSeparator;
+
     /**
      * ArrayAdapter constructor.
      * @param array $data
+     * @param string $multipleValueSeparator
      */
-    public function __construct($data)
+    public function __construct($data, $multipleValueSeparator = ', ')
     {
+        $this->multipleValueSeparator = $multipleValueSeparator;
+
         parent::__construct($data);
         foreach ($this->_array as &$row) {
             foreach ($row as $colName => &$value)
@@ -30,11 +35,11 @@ class NestedArrayAdapter extends ArrayAdapter
      * Transform nested array to string
      *
      * @param array $line
-     * @return array
+     * @return void
      */
     protected function convertToArray(&$line)
     {
-        $implodeStr = ', ';
+        $implodeStr = $this->multipleValueSeparator;
         $arr = array_map(
             function ($value, $key) use (&$implodeStr) {
                 if (is_array($value) && is_numeric($key)) {

--- a/Model/Adapters/NestedArrayAdapterFactory.php
+++ b/Model/Adapters/NestedArrayAdapterFactory.php
@@ -21,7 +21,7 @@ class NestedArrayAdapterFactory implements ImportAdapterFactoryInterface
 
     /**
      * @param array $data
-     * @return \FireGento\FastSimpleImport\Model\Adapters\ArrayAdapter
+     * @return \FireGento\FastSimpleImport\Model\Adapters\NestedArrayAdapter
      */
     public function create(array $data = [])
     {

--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -118,7 +118,12 @@ class Importer
     protected function _validateData($dataArray)
     {
         $importModel = $this->createImportModel();
-        $source = $this->importAdapterFactory->create(array('data' => $dataArray));
+        $source = $this->importAdapterFactory->create(
+            array(
+                'data' => $dataArray,
+                'multipleValueSeparator' => $this->getMultipleValueSeparator()
+            )
+        );
         $this->validationResult = $importModel->validateSource($source);
         $this->addToLogTrace($importModel);
         return $this->validationResult;


### PR DESCRIPTION
Added possibility to pass multiple value separator, configured in Importer model, to NestedArrayAdapter.

The problem raised when importing configurable products and multiple value separator was different than default hard-coded comma(,).

Also fixed some type hints in comments.