### PR TITLE
MISC Relax PHP version constraint to support Magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Wrapper for Magento2 ImportExport functionality, which imports products and customers from arrays",
   "homepage": "https://github.com/firegento/FireGento_FastSimpleImport2",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0"
+    "php": "~5.5.0|~5.6.0|~7.0"
   },
   "type": "magento2-module",
   "license": "GPL-3.0",


### PR DESCRIPTION
Magento 2.2 requires PHP 7.1, we're using this module with CtiConfigurator and all good so far, just needs the PHP version constraint relaxing slightly.