### PR TITLE
Added return value for the validation result in processImport function

### DIFF
--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -111,9 +111,12 @@ class Importer
 
     public function processImport($dataArray)
     {
-        if ($this->_validateData($dataArray)) {
+        $validation = $this->_validateData($dataArray);
+        if ($validation) {
             $this->_importData();
         }
+
+        return $validation;
     }
 
     protected function _validateData($dataArray)


### PR DESCRIPTION
Currently there is no clear way of knowing if the import validation ran correctly when calling the processImport function in FireGento\FastSimpleImport\Model\Importer. Only the _importData function is adding errors so calling getErrorMessages() after the processImport function is not an option to see if the validation was succesfull.

By returning the validation result in the processImport it allows for implementations which can run when the validation fails (e.g throwing exceptions, fixing the data, etc.)