### PR TITLE
Optionally use temporary table for validated import data

### DIFF
--- a/ResourceModel/ImportData.php
+++ b/ResourceModel/ImportData.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FireGento\FastSimpleImport\ResourceModel;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+/**
+ * Overriden resource model for import data. Since we do not upload and validate CSV files, then process the uploaded
+ * data in a second step, we can use a temporary table.
+ *
+ * This not only improves performance, it also allows for parallel import execution, because each process uses its own
+ * temporary table.
+ *
+ * @package FireGento\FastSimpleImport\ResourceModel
+ */
+class ImportData extends \Magento\ImportExport\Model\ResourceModel\Import\Data
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    public function __construct(
+        \Magento\Framework\Model\ResourceModel\Db\Context $context,
+        \Magento\Framework\Json\Helper\Data $jsonHelper,
+        ScopeConfigInterface $scopeConfig,
+        $connectionName = null
+    )
+    {
+        $this->scopeConfig = $scopeConfig;
+        parent::__construct($context, $jsonHelper, $connectionName);
+    }
+
+    protected function _construct()
+    {
+        if ($this->scopeConfig->isSetFlag('fastsimpleimport/database/import_temp_table')) {
+            $this->getConnection()->createTemporaryTableLike(
+                'importexport_importdata_tmp',
+                'importexport_importdata',
+                true
+            );
+            $this->_init('importexport_importdata_tmp', 'id');
+        } else {
+            parent::_construct();
+        }
+    }
+
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -40,6 +40,14 @@
                     <label>Category path seperator</label>
                 </field>
             </group>
+            <group id="database" translate="label" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Database settings</label>
+                <field id="import_temp_table" type="select" sortOrder="10" showInDefault="1" translate="label,comment">
+                    <label>Create temporary table for validated import_data</label>
+                    <comment>This will create a temporary table instead of using the regular table. It allows parallel execution of imports without data loss. But it will not be possible anymore to upload CSV import files in the admin panel.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -5,7 +5,10 @@
  * See LICENSE.md bundled with this module for license details.
  */
  -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="\FireGento\FastSimpleImport\Model\Adapters\ImportAdapterFactoryInterface" type="FireGento\FastSimpleImport\Model\Adapters\ArrayAdapterFactory"/>
-
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="\FireGento\FastSimpleImport\Model\Adapters\ImportAdapterFactoryInterface"
+                type="FireGento\FastSimpleImport\Model\Adapters\ArrayAdapterFactory"/>
+    <preference for="Magento\ImportExport\Model\ResourceModel\Import\Data"
+                type="FireGento\FastSimpleImport\ResourceModel\ImportData"/>
 </config>


### PR DESCRIPTION
This not only improves performance, it also allows for parallel import execution, because each process uses its own temporary table.