### PR TITLE
Fix category update with category ID

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -1095,6 +1095,10 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
         if ($rowData[self::COL_CATEGORY] == $this->getCategoryName($rowData)) {
             // if _category eq. name then we don't have parents
             $parent = false;
+        } elseif (is_numeric($rowData[self::COL_CATEGORY]) && isset($this->categoriesWithRoots[$rowData[self::COL_ROOT]][$rowData[self::COL_CATEGORY]])) {
+            // existing category given via ID, retrieve correct parent
+            $categoryParts = explode('/', $this->categoriesWithRoots[$rowData[self::COL_ROOT]][$rowData[self::COL_CATEGORY]][CategoryModel::KEY_PATH]);
+            $parent = $categoryParts[count($categoryParts) - 2];
         } else {
             $categoryParts = $this->explodeEscaped($this->_scopeConfig->getValue(Config::XML_PATH_CATEGORY_PATH_SEPERATOR), $rowData[self::COL_CATEGORY]);
             array_pop($categoryParts);


### PR DESCRIPTION
Currently, updating a category with a level greater than 2 by its ID leads to the issue that the category is moved to another level. The root cause is that a wrong parent category is retrieved in this case. Example:

![image](https://user-images.githubusercontent.com/930199/113986066-1e1c3180-984d-11eb-8aa6-340b28dc23e9.png)

In the above example, currently, no parent is found and therefore, the root category `1/2` will be used as a parent. Instead, `1/2/26` needs to be taken as a parent.