### PR TITLE
Return the complete category image path

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -1298,7 +1298,7 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
     {
         try {
             $res = $this->getUploader()->move($fileName);
-            return $res['file'];
+            return '/media/catalog/category' . $res['file'];
         } catch (\Exception $e) {
             return '';
         }


### PR DESCRIPTION
When a category image is imported, it's saved without the `media/catalog/category` path.

For instance, if I import a `main.jpg` image, it will be saved as `/m/a/main.jpg`, causing a 404 when the image is displayed.

I'm not sure if it's the cleanest way to do it tho.