### PR TITLE
Category Import fixes

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -117,6 +117,9 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
      */
     private ?string $entityTable = null;
 
+    /**
+     * Attributes with index (not label) value.
+     */
     private array $indexValueAttributes = [
         'default_sort_by',
         CategoryInterface::KEY_AVAILABLE_SORT_BY,

--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -117,9 +117,6 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
      */
     private ?string $entityTable = null;
 
-    /**
-     * Attributes with index (not label) value.
-     */
     private array $indexValueAttributes = [
         'default_sort_by',
         CategoryInterface::KEY_AVAILABLE_SORT_BY,
@@ -335,7 +332,13 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
 
         if ($attribute->usesSource()) {
             // should attribute has index (option value) instead of a label?
-            $index = in_array($attribute->getAttributeCode(), $this->indexValueAttributes) ? 'value' : 'label';
+            $index = 'label';
+            if (
+                in_array($attribute->getAttributeCode(), $this->indexValueAttributes) ||
+                $attribute->getSourceModel() == "Magento\Eav\Model\Entity\Attribute\Source\Boolean"
+            ) {
+                $index = 'value';
+            };
 
             // only default (admin) store values used
             /** @var Attribute $attribute */

--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -274,6 +274,8 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
             $this->getErrorAggregator()->addErrorMessageTemplate($errorCode, $message);
         }
 
+        $this->config                       = $config;
+
         $this->initOnTapAttributes()
             ->initWebsites()
             ->initStores()
@@ -283,7 +285,6 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
 
         $this->entityTable                  = $this->defaultCategory->getResource()->getEntityTable();
         $this->categoryImportVersionFeature = $this->versionFeatures->create('CategoryImportVersion');
-        $this->config                       = $config;
     }
 
     /**

--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -41,6 +41,7 @@ use Magento\CatalogImportExport\Model\Import\UploaderFactory;
 use Magento\Framework\Filesystem;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Eav\Model\Entity\Attribute\Source\Boolean;
 
 /**
  * Entity Adapter for importing Magento Categories
@@ -339,7 +340,7 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
             $index = 'label';
             if (
                 in_array($attribute->getAttributeCode(), $this->indexValueAttributes) ||
-                $attribute->getSourceModel() == "Magento\Eav\Model\Entity\Attribute\Source\Boolean"
+                $attribute->getSourceModel() == Boolean::class
             ) {
                 $index = 'value';
             };

--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -954,13 +954,13 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
 
                     $time = !empty($rowData[CategoryModel::KEY_CREATED_AT])
                         ? strtotime($rowData[CategoryModel::KEY_CREATED_AT])
-                        : null;
+                        : 'now';
 
                     // entity table data
                     $entityRow = [
                         CategoryInterface::KEY_PARENT_ID => $parentCategory['entity_id'],
                         CategoryInterface::KEY_LEVEL => $parentCategory[CategoryInterface::KEY_LEVEL] + 1,
-                        CategoryInterface::KEY_CREATED_AT => (new DateTime($time))
+                        CategoryInterface::KEY_CREATED_AT => (new \DateTime($time))
                             ->format(DateTime::DATETIME_PHP_FORMAT),
                         CategoryInterface::KEY_UPDATED_AT => "now()",
                         CategoryInterface::KEY_POSITION => $rowData[CategoryInterface::KEY_POSITION]

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,6 +14,7 @@
                 <validation_strategy>validation-stop-on-errors</validation_strategy>
                 <allowed_error_count>0</allowed_error_count>
                 <ignore_duplicates>0</ignore_duplicates>
+                <category_path_seperator>/</category_path_seperator>
             </default>
             <database>
                 <import_temp_table>1</import_temp_table>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,7 +14,6 @@
                 <validation_strategy>validation-stop-on-errors</validation_strategy>
                 <allowed_error_count>0</allowed_error_count>
                 <ignore_duplicates>0</ignore_duplicates>
-                <category_path_seperator>/</category_path_seperator>
             </default>
             <database>
                 <import_temp_table>1</import_temp_table>


### PR DESCRIPTION
This has the compatibility fixes I commented on, sets a default category_path_seperator "/", and reverses the parameters for explodeEscaped because having the first parameter optional is deprecated.