### PR TITLE
PHP 8.1 - Fix optional parameter error

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -1063,8 +1063,11 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
      * @param string $string
      * @return array
      */
-    protected function explodeEscaped($delimiter = '/', $string)
+    protected function explodeEscaped($delimiter, $string)
     {
+        if (!$delimiter) {
+            $delimiter = '/';
+        }
         $exploded = explode($delimiter, $string);
         $fixed = [];
         for ($k = 0, $l = count($exploded); $k < $l; ++$k) {


### PR DESCRIPTION
With PHP 8.1, fix the following error
```
Deprecated Functionality: Optional parameter $delimiter declared before required parameter $string is implicitly treated as a required parameter in /var/www/html/vendor/firegento/fastsimpleimport/Model/Import/Category.php on line 106
```

That's because `$delimiter` can't be optional if the following parameter `$string` is not.