### PR TITLE
Fix categories import URL, load them with repository

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -800,8 +800,8 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
     protected function reindexUpdatedCategories($categoryId)
     {
         /** @var $category \Magento\Catalog\Model\Category */
-        $category = $this->defaultCategory->load($categoryId);
-        //$categoryName = $category->getName();
+        $category = $this->categoryRepository->get($categoryId);
+        
         foreach ($category->getStoreIds() as $storeId) {
             if ($storeId == 0) {
                 continue;


### PR DESCRIPTION
Hello,
I had some issues with the generated categories URL rewrites and I noticed it was due to the way they are loaded.
It seems some data from other categories are still in the `defaultCategory` object and leads Magento to a bad URL generation, especially in a multi-stores store.

IMO it's better to load categories with the repository anyway.