### PR TITLE
Fix deprecated functionality

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -1063,7 +1063,7 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
      * @param string $string
      * @return array
      */
-    protected function explodeEscaped($delimiter = '/', $string)
+    protected function explodeEscaped($delimiter, $string)
     {
         $exploded = explode($delimiter, $string);
         $fixed = [];


### PR DESCRIPTION
Deprecated Functionality: Optional parameter $delimiter declared before required parameter $string is implicitly treated as a required parameter