### PR TITLE
Don't use the same import model for validation and import

### DIFF
--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -81,6 +81,7 @@ class Importer
      */
     private function importData()
     {
+        $this->resetImportModel();
         $importModel = $this->getImportModel();
         $importModel->importSource();
         $this->handleImportResult($importModel);
@@ -109,6 +110,11 @@ class Importer
             $this->importModel->setData($this->settings);
         }
         return $this->importModel;
+    }
+
+    public function resetImportModel(): void
+    {
+        $this->importModel = null;
     }
 
     public function getErrorAggregator(): ProcessingErrorAggregatorInterface


### PR DESCRIPTION
If we create new options during validation (by "before" plugin to \Magento\CatalogImportExport\Model\Import\Product\Validator::isAttributeValid), we need to re-init it so the new option is available during import.

This restores the behavior from version 1.x.