### PR TITLE
Reset import model between imports

### DIFF
--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -53,6 +53,7 @@ class Importer
      */
     public function processImport(array $dataArray): void
     {
+        $this->resetImportModel();
         $this->validateData($dataArray);
         $this->importData();
     }
@@ -109,6 +110,11 @@ class Importer
             $this->importModel->setData($this->settings);
         }
         return $this->importModel;
+    }
+
+    private function resetImportModel(): void
+    {
+        $this->importModel = null;
     }
 
     public function getErrorAggregator(): ProcessingErrorAggregatorInterface


### PR DESCRIPTION
This should fix #133.

The import model caches the validated rows internally. When calling processImport multiple times, the validation logic will not be applied correctly during the second call, leading to an exception during import.

This bug was introduced in [this commit](https://github.com/firegento/FireGento_FastSimpleImport2/commit/3e391398228b51a69fa9a263e65c80baeb88d8bd#diff-9d5ee92bb1dea4e5db29273f80eb45e1676561a2900b9e7c6ad38deaa140ac87). Before that, a new import model was created for each call to processImport.