### PR TITLE
Add default value for category path separator again

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,6 +14,7 @@
                 <validation_strategy>validation-stop-on-errors</validation_strategy>
                 <allowed_error_count>0</allowed_error_count>
                 <ignore_duplicates>0</ignore_duplicates>
+                <category_path_seperator>/</category_path_seperator>
             </default>
             <database>
                 <import_temp_table>1</import_temp_table>


### PR DESCRIPTION
This somehow got removed in https://github.com/firegento/FireGento_FastSimpleImport2/pull/120/files#diff-3bf05ed19b66e6338063bab879891ccbe11ba078352dec2a9ec57ec37bff15bb leading to a type error by default:

    FireGento\FastSimpleImport\Model\Config::getCategoryPathSeparator(): Return value must be of type string, null returned