### PR TITLE
Fix compatibility with ExtendedImport

### DIFF
--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -55,6 +55,7 @@ class Importer
     {
         $this->resetImportModel();
         $this->validateData($dataArray);
+        $this->resetImportModel();
         $this->importData();
     }
 


### PR DESCRIPTION
[FireGento_ExtendedImport2](https://github.com/firegento/FireGento_ExtendedImport2) will create missing attribute options on-the-fly during the validation step. Hence, if we do not reset the import model after the validation call, the new values will not be picked up, because the values are still cached inside `\Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType::$commonAttributesCache`.