### PR TITLE
Ignore empty value for certain category attributes

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -172,6 +172,17 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
         self::COL_CATEGORY
     ];
 
+    /**
+     * List of fields that can used config values in case when value does not defined directly
+     *
+     * @var array
+     */
+    protected $useConfigFields = [
+        'available_sort_by',
+        'default_sort_by',
+        'filter_price_range'
+    ];
+
     private ?int $errorsLimit = null;
     private array $invalidRows = [];
 
@@ -816,7 +827,8 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
             foreach ($this->attributes as $attrCode => $attrParams) {
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $this->isAttributeValid($attrCode, $attrParams, $rowData, $rowNum);
-                } elseif ($attrParams['is_required'] && !isset($this->categoriesWithRoots[$root][$category])) {
+                } elseif ($attrParams['is_required'] && !isset($this->categoriesWithRoots[$root][$category])
+                    && !in_array($attrCode, $this->useConfigFields)) {
                     $this->addRowError(self::ERROR_VALUE_IS_REQUIRED, $rowNum, $attrCode);
                 }
             }


### PR DESCRIPTION
Magento has the following attributes which are allowed to be overruled by marking the "use config" checkbox.
Using this importer I did not find any way to pass an empty value for these required attributes, hence this pull request.

During the category validation in Magento (`\Magento\Catalog\Model\CategoryRepository::validateCategory`) these fields are stored in a data attribute named `use_post_data_config`. If no value is passed for these fields the required validation gets ignored.

This pull request kind of copies this behaviour and allows the user to pass an empty value in the category importer.