### PR TITLE
#146 Addition of a setter for the 'locale' data on the importer model.

### DIFF
--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -156,6 +156,16 @@ class Importer
     /**
      * @throws RuntimeException
      */
+    public function setImportLocale(?string $locale): self
+    {
+        $this->assertImportModelNotInitialized();
+        $this->settings['locale'] = $locale;
+        return $this;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
     public function setValidationStrategy(string $strategy): self
     {
         $this->assertImportModelNotInitialized();


### PR DESCRIPTION
Following the Issue I opened earlier (https://github.com/firegento/FireGento_FastSimpleImport2/issues/146)

Here is the PR adding a setter for the locale data to be given to the Magento Import model.

Kind Regards,
Baptiste
