### PR TITLE
Fixes boolean cast, old way is deprecated in PHP 8.5

### DIFF
--- a/Model/Import/Category.php
+++ b/Model/Import/Category.php
@@ -662,7 +662,7 @@ class Category extends \Magento\ImportExport\Model\Import\AbstractEntity
      */
     public function setIgnoreDuplicates($value): self
     {
-        $this->_parameters['ignore_duplicates'] = (boolean)$value;
+        $this->_parameters['ignore_duplicates'] = (bool)$value;
         return $this;
     }
 


### PR DESCRIPTION
We're upgrading a Magento shop of a client of ours with this module installed from Magento 2.4.6 to 2.4.9 and PHP from 8.2 to 8.5

However, when running `bin/magento setup:di:compile` after the upgrades, we get this error:
```
$ bin/magento setup:di:compile
Compilation was started.
Repositories code generation... 1/9 [===>------------------------]  11% 1 s 80.0 MiB
In ErrorHandler.php line 61:

  Deprecated Functionality: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in vendor/firegento/fastsimpleimport/Model/Import/Category.php on line 665
```

This PR fixes this.
See https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.non-canonical-cast-names for why it happens.


I've checked with PHPCompatibilityChecker to see if any other PHP incompatibility exists with PHP 8.4/8.5 and that's not the case 💪 
No idea yet about compatibility with Magento 2.4.9, that will be tested later on.